### PR TITLE
feat: generate default constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ import 'package:struct_annotation/struct_annotation.dart';
 
 @Struct()
 class Person {
-  const Person({required this.name, required this.age});
-
   final String name;
   final int age;
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -7,7 +7,7 @@ class Person {
 }
 
 void main() {
-  final jane = Person('Jane', 42);
+  final jane = Person(name: 'Jane', age: 42);
   final john = jane.copyWith(name: 'John');
 
   print(jane); // Person(name: Jane, age: 42)

--- a/example/main.dart
+++ b/example/main.dart
@@ -2,14 +2,12 @@ import 'package:struct_annotation/struct_annotation.dart';
 
 @Struct()
 class Person {
-  const Person({required this.name, required this.age});
-
   final String name;
   final int age;
 }
 
 void main() {
-  final jane = Person(name: 'Jane', age: 42);
+  final jane = Person('Jane', 42);
   final john = jane.copyWith(name: 'John');
 
   print(jane); // Person(name: Jane, age: 42)

--- a/lib/src/struct_annotation.dart
+++ b/lib/src/struct_annotation.dart
@@ -254,7 +254,7 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
 
     return builder.declareInType(
       DeclarationCode.fromParts([
-        '${clazz.identifier.name}({',
+        'const ${clazz.identifier.name}({',
         for (final field in fields)
           ...['required', ' ', 'this.', field.identifier.name, ','],
         '});',

--- a/lib/src/struct_annotation.dart
+++ b/lib/src/struct_annotation.dart
@@ -236,15 +236,15 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
   }
 
   Future<void> _declareDefaultConstructor(
-      ClassDeclaration clazz,
-      MemberDeclarationBuilder builder,
-      ) async {
+    ClassDeclaration clazz,
+    MemberDeclarationBuilder builder,
+  ) async {
     final fieldDeclarations = await builder.fieldsOf(clazz);
     final fields = await Future.wait(
       fieldDeclarations.map(
-            (f) async => (
-        identifier: f.identifier,
-        type: _checkNamedType(f.type, builder),
+        (f) async => (
+          identifier: f.identifier,
+          type: _checkNamedType(f.type, builder),
         ),
       ),
     );
@@ -253,12 +253,14 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
     if (missingType != null) return null;
 
     return builder.declareInType(
-      DeclarationCode.fromParts([
-        'const ${clazz.identifier.name}({',
-        for (final field in fields)
-          ...['required', ' ', 'this.', field.identifier.name, ','],
-        '});',
-      ]),
+      DeclarationCode.fromParts(
+        [
+          'const ${clazz.identifier.name}({',
+          for (final field in fields)
+            ...['required', ' ', 'this.', field.identifier.name, ','],
+          '});',
+        ],
+      ),
     );
   }
 

--- a/lib/src/struct_annotation.dart
+++ b/lib/src/struct_annotation.dart
@@ -228,7 +228,7 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
           clazzName,
           '(',
           for (final field in fields)
-          ...[field.identifier.name, ' ?? ', 'this.',field.identifier.name, ','],
+            ...[field.identifier.name,': ', field.identifier.name, ' ?? ', 'this.',field.identifier.name, ','],
           ');'
         ],
       ),
@@ -254,12 +254,10 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
 
     return builder.declareInType(
       DeclarationCode.fromParts([
-        '${clazz.identifier.name}(',
+        '${clazz.identifier.name}({',
         for (final field in fields)
-          ...[field.type!.identifier.name, ' ', field.identifier.name, ',']
-        ,') : ',
-        for (var i = 0; i < fields.length; i++)
-          ...['this', '.', fields[i].identifier.name, ' = ', fields[i].identifier.name, (i == fields.length -1) ? ';' : ',']
+          ...['required', ' ', 'this.', field.identifier.name, ','],
+        '});',
       ]),
     );
   }

--- a/lib/src/struct_annotation.dart
+++ b/lib/src/struct_annotation.dart
@@ -264,7 +264,6 @@ macro class Struct with _Shared implements ClassDeclarationsMacro, ClassDefiniti
 
 }
 
-
 mixin _Shared {
   NamedTypeAnnotation? _checkNamedType(TypeAnnotation type, Builder builder) {
     if (type is NamedTypeAnnotation) return type;


### PR DESCRIPTION
Fixes https://github.com/felangel/struct/pull/8

This PR generates default constructors for annotated classes:

## Definition

```dart
@Struct()
class Person {
  final String name;
  final int age;
}
```

## Usage

```dart
  final jane = Person('Jane', 42);
```